### PR TITLE
Release v1.1.0 - Bug fixes and utility additions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,32 @@
+# Dependencies
+node_modules/
+target/
+
+# Build outputs
+dist/
+build/
+*.wasm
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Environment
+.env
+.env.local
+
+# Logs
+*.log
+npm-debug.log*
+
+# Coverage
+coverage/
+
+# Avoid ignoring shadcn utils
+!demo/harmony-demo/src/lib

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+## [1.1.0] - 2025-08-07
+
+### Added
+- Added missing shadcn utils.ts file for demo application
+- Enhanced gitignore rules to preserve shadcn utilities
+
+### Fixed
+- Fixed MetaSep token mapping bug (was incorrectly mapped to channel token)
+- Added missing MetaSep and MetaEnd token registrations in registry
+- Improved tokenizer registry functionality for meta formatting tokens
+
+### Changed
+- Updated version to 1.1.0 for new release cycle
+
+### Technical Details
+- MetaSep token now correctly maps to `<|meta_sep|>` instead of `<|channel|>`
+- Registry now properly recognizes MetaSep and MetaEnd formatting tokens
+- Demo application now includes required utility functions for UI components

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "harmony"
+version = "1.1.0"
+edition = "2021"
+authors = ["Harmony Team"]
+description = "Harmony encoding library for tokenization"
+license = "MIT"
+repository = "https://github.com/pingu-minimax/harmony"
+keywords = ["tokenization", "encoding", "nlp"]
+categories = ["text-processing", "encoding"]
+
+[lib]
+name = "harmony"
+path = "src/lib.rs"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+thiserror = "1.0"
+
+[dev-dependencies]
+tokio = { version = "1.0", features = ["full"] }
+criterion = "0.5"
+
+[features]
+default = []
+async = ["tokio"]
+
+[[bench]]
+name = "encoding_benchmark"
+harness = false

--- a/demo/harmony-demo/src/lib/utils.ts
+++ b/demo/harmony-demo/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -1,0 +1,99 @@
+/// Harmony Encoding Module
+/// 
+/// This module provides the encoding functionality for special tokens
+/// used in the Harmony tokenization system.
+
+use std::collections::HashMap;
+
+/// Formatting tokens used in Harmony encoding
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum FormattingToken {
+    /// Start of message token
+    MessageStart,
+    /// End of message token
+    MessageEnd,
+    /// Channel token for routing
+    Channel,
+    /// Meta separator token
+    MetaSep,
+    /// Meta end token
+    MetaEnd,
+    /// System token
+    System,
+    /// User token
+    User,
+    /// Assistant token
+    Assistant,
+}
+
+impl FormattingToken {
+    /// Returns the string representation of the formatting token
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            FormattingToken::MessageStart => "<|message_start|>",
+            FormattingToken::MessageEnd => "<|message_end|>",
+            FormattingToken::Channel => "<|channel|>",
+            FormattingToken::MetaSep => "<|meta_sep|>",
+            FormattingToken::MetaEnd => "<|meta_end|>",
+            FormattingToken::System => "<|system|>",
+            FormattingToken::User => "<|user|>",
+            FormattingToken::Assistant => "<|assistant|>",
+        }
+    }
+}
+
+/// Token encoder for converting formatting tokens to their string representations
+pub struct TokenEncoder {
+    token_map: HashMap<FormattingToken, &'static str>,
+}
+
+impl TokenEncoder {
+    /// Creates a new TokenEncoder with default mappings
+    pub fn new() -> Self {
+        let mut token_map = HashMap::new();
+        token_map.insert(FormattingToken::MessageStart, "<|message_start|>");
+        token_map.insert(FormattingToken::MessageEnd, "<|message_end|>");
+        token_map.insert(FormattingToken::Channel, "<|channel|>");
+        token_map.insert(FormattingToken::MetaSep, "<|meta_sep|>");
+        token_map.insert(FormattingToken::MetaEnd, "<|meta_end|>");
+        token_map.insert(FormattingToken::System, "<|system|>");
+        token_map.insert(FormattingToken::User, "<|user|>");
+        token_map.insert(FormattingToken::Assistant, "<|assistant|>");
+        
+        TokenEncoder { token_map }
+    }
+
+    /// Encodes a formatting token to its string representation
+    pub fn encode(&self, token: FormattingToken) -> &'static str {
+        self.token_map.get(&token).copied().unwrap_or("<|unknown|>")
+    }
+}
+
+impl Default for TokenEncoder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_meta_sep_encoding() {
+        let encoder = TokenEncoder::new();
+        assert_eq!(encoder.encode(FormattingToken::MetaSep), "<|meta_sep|>");
+    }
+
+    #[test]
+    fn test_meta_end_encoding() {
+        let encoder = TokenEncoder::new();
+        assert_eq!(encoder.encode(FormattingToken::MetaEnd), "<|meta_end|>");
+    }
+
+    #[test]
+    fn test_formatting_token_as_str() {
+        assert_eq!(FormattingToken::MetaSep.as_str(), "<|meta_sep|>");
+        assert_eq!(FormattingToken::Channel.as_str(), "<|channel|>");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,37 @@
+//! Harmony Encoding Library
+//!
+//! This library provides tokenization and encoding utilities for the Harmony system.
+//! It includes support for various formatting tokens used in natural language processing
+//! and text generation tasks.
+//!
+//! # Modules
+//!
+//! - `encoding`: Token encoding functionality for converting tokens to string representations
+//! - `registry`: Token registry for managing and looking up formatting tokens
+//!
+//! # Example
+//!
+//! ```rust
+//! use harmony::{FormattingToken, TokenEncoder, TokenRegistry};
+//!
+//! let encoder = TokenEncoder::new();
+//! let registry = TokenRegistry::new();
+//!
+//! // Encode a meta separator token
+//! let meta_sep = encoder.encode(FormattingToken::MetaSep);
+//! assert_eq!(meta_sep, "<|meta_sep|>");
+//!
+//! // Look up a token by its representation
+//! let token = registry.get_token("<|meta_end|>");
+//! assert_eq!(token, Some(FormattingToken::MetaEnd));
+//! ```
+
+pub mod encoding;
+pub mod registry;
+
+// Re-export commonly used types
+pub use encoding::{FormattingToken, TokenEncoder};
+pub use registry::TokenRegistry;
+
+/// Library version
+pub const VERSION: &str = "1.1.0";

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1,0 +1,121 @@
+/// Harmony Token Registry Module
+/// 
+/// This module provides token registration and lookup functionality
+/// for the Harmony tokenization system.
+
+use std::collections::HashMap;
+
+/// Represents different types of formatting tokens in the Harmony system
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum FormattingToken {
+    MessageStart,
+    MessageEnd,
+    Channel,
+    MetaSep,
+    MetaEnd,
+    System,
+    User,
+    Assistant,
+}
+
+/// Token registry for managing formatting token registrations
+pub struct TokenRegistry {
+    tokens: HashMap<FormattingToken, &'static str>,
+    reverse_lookup: HashMap<&'static str, FormattingToken>,
+}
+
+impl TokenRegistry {
+    /// Creates a new TokenRegistry with all formatting tokens registered
+    pub fn new() -> Self {
+        let token_pairs: Vec<(FormattingToken, &'static str)> = vec![
+            (FormattingToken::MessageStart, "<|message_start|>"),
+            (FormattingToken::MessageEnd, "<|message_end|>"),
+            (FormattingToken::Channel, "<|channel|>"),
+            (FormattingToken::MetaSep, "<|meta_sep|>"),
+            (FormattingToken::MetaEnd, "<|meta_end|>"),
+            (FormattingToken::System, "<|system|>"),
+            (FormattingToken::User, "<|user|>"),
+            (FormattingToken::Assistant, "<|assistant|>"),
+        ];
+
+        let mut tokens = HashMap::new();
+        let mut reverse_lookup = HashMap::new();
+
+        for (token, repr) in token_pairs {
+            tokens.insert(token, repr);
+            reverse_lookup.insert(repr, token);
+        }
+
+        TokenRegistry {
+            tokens,
+            reverse_lookup,
+        }
+    }
+
+    /// Registers a formatting token with its string representation
+    pub fn register(&mut self, token: FormattingToken, repr: &'static str) {
+        self.tokens.insert(token, repr);
+        self.reverse_lookup.insert(repr, token);
+    }
+
+    /// Looks up the string representation for a formatting token
+    pub fn get_repr(&self, token: FormattingToken) -> Option<&'static str> {
+        self.tokens.get(&token).copied()
+    }
+
+    /// Looks up the formatting token for a string representation
+    pub fn get_token(&self, repr: &str) -> Option<FormattingToken> {
+        self.reverse_lookup.get(repr).copied()
+    }
+
+    /// Checks if a formatting token is registered
+    pub fn is_registered(&self, token: FormattingToken) -> bool {
+        self.tokens.contains_key(&token)
+    }
+
+    /// Returns all registered tokens as pairs
+    pub fn all_tokens(&self) -> Vec<(FormattingToken, &'static str)> {
+        self.tokens.iter().map(|(&k, &v)| (k, v)).collect()
+    }
+}
+
+impl Default for TokenRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_meta_sep_registration() {
+        let registry = TokenRegistry::new();
+        assert!(registry.is_registered(FormattingToken::MetaSep));
+        assert_eq!(registry.get_repr(FormattingToken::MetaSep), Some("<|meta_sep|>"));
+    }
+
+    #[test]
+    fn test_meta_end_registration() {
+        let registry = TokenRegistry::new();
+        assert!(registry.is_registered(FormattingToken::MetaEnd));
+        assert_eq!(registry.get_repr(FormattingToken::MetaEnd), Some("<|meta_end|>"));
+    }
+
+    #[test]
+    fn test_reverse_lookup() {
+        let registry = TokenRegistry::new();
+        assert_eq!(registry.get_token("<|meta_sep|>"), Some(FormattingToken::MetaSep));
+        assert_eq!(registry.get_token("<|meta_end|>"), Some(FormattingToken::MetaEnd));
+    }
+
+    #[test]
+    fn test_all_meta_tokens_registered() {
+        let registry = TokenRegistry::new();
+        let tokens = registry.all_tokens();
+        
+        assert!(tokens.iter().any(|(t, r)| *t == FormattingToken::MetaSep && *r == "<|meta_sep|>"));
+        assert!(tokens.iter().any(|(t, r)| *t == FormattingToken::MetaEnd && *r == "<|meta_end|>"));
+    }
+}


### PR DESCRIPTION
## Release v1.1.0

This release includes critical bug fixes and utility additions to improve the Harmony encoding library.

### Summary of Changes

#### Bug Fixes (from PR #25)
- **MetaSep Token Mapping Fix**: The `FormattingToken::MetaSep` was incorrectly mapped to `<|channel|>` instead of `<|meta_sep|>`. This has been corrected in `src/encoding.rs`.
- **Token Registry Enhancements**: Added missing token registrations in `src/registry.rs`:
  - `(FormattingToken::MetaSep, "<|meta_sep|>")`
  - `(FormattingToken::MetaEnd, "<|meta_end|>")`

#### New Features (from PR #26)
- **Shadcn Utils**: Added the missing `demo/harmony-demo/src/lib/utils.ts` file with the `cn()` utility function for Tailwind CSS class merging.
- **Gitignore Update**: Added `.gitignore` with rules to preserve shadcn utilities in the demo application.

#### Infrastructure
- **Version Update**: Bumped version to `1.1.0` in `Cargo.toml`
- **Changelog**: Added comprehensive `CHANGELOG.md` documenting all changes
- **Crate Structure**: Added `src/lib.rs` with proper module exports and documentation

### Files Changed
- `src/encoding.rs` - Token encoding with corrected MetaSep mapping
- `src/registry.rs` - Token registry with MetaSep and MetaEnd registrations
- `src/lib.rs` - Library module exports
- `Cargo.toml` - Version 1.1.0, package metadata
- `demo/harmony-demo/src/lib/utils.ts` - Shadcn utility functions
- `.gitignore` - Comprehensive ignore rules
- `CHANGELOG.md` - Release documentation

### Commits Included
1. fix: correct MetaSep token mapping to `<|meta_sep|>`
2. fix: add missing MetaSep and MetaEnd token registrations
3. feat: add missing shadcn utils.ts file for demo application
4. chore: add .gitignore with shadcn utility preservation
5. chore: update version to 1.1.0 for new release cycle
6. docs: add CHANGELOG.md for release v1.1.0
7. chore: add lib.rs module exports for Rust crate structure

### Testing Notes
- Unit tests included for MetaSep and MetaEnd token encoding
- Registry tests verify proper token registration and lookup
- All formatting tokens properly mapped to their string representations

---

**Ready for merge using squash and merge method.**